### PR TITLE
Enabled deleting tags.

### DIFF
--- a/autoload/id3.vim
+++ b/autoload/id3.vim
@@ -92,7 +92,7 @@ function! id3#UpdateMp3(filename)
   let tags.g = s:FindTagValue('Genre')
   let tags.c = s:FindTagValue('Comment')
 
-  let command_line = 'id3 '
+  let command_line = 'id3 -d '
   for [key, value] in items(tags)
     if value != ''
       let command_line .= '-'.key.' '.shellescape(value).' '


### PR DESCRIPTION
ID3 Documentation:
```
       -d, --delete
              do  not  re-use  existing  tag data. If no new tag information is specified in conjunction with
              this option, all selected tags will be removed.
```
Without the -d option, I couldn't delete any tags for mp3s.